### PR TITLE
Allow builds to specify env vars in cdflow.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/mergermarket/cdflow2)
 ![GitHub](https://img.shields.io/github/license/mergermarket/cdflow2)
 
-
+For usages documentation be refer to: https://developer-preview.acuris.com/opensource/cdflow2/
 
 ## Containers
 

--- a/docs/src/cdflow-yaml-reference.md
+++ b/docs/src/cdflow-yaml-reference.md
@@ -28,6 +28,11 @@ config:
 builds:
   docker:
     image: mergermarket/cdflow2-build-docker-ecr
+    # optional - list of env var that key and value should
+    # be copied to the build/release container
+    env_vars:
+      - FOO
+      - BAR
   lambda:
     image: mergermarket/cdflow2-build-lambda
     params:
@@ -112,6 +117,32 @@ The image used to do the build. Examples include:
 A dictionary of parameters passed to the build container. What parameters
 are supported depends on the build container used, so check the specific
 documentation for that image.
+
+#### `builds > [name] > env_vars` (optional)
+
+The builds.[name].env_vars configuration allows specific environment variables to be injected into the release/build container at runtime.
+
+This was needed because some builds require access to artifacts behind secure authentication.
+
+Note: this config does not define values for the variables. Instead, it copies the specified environment variables from the build environment into the container. For example, if the build environment has FOO_APIKEY=secret123 and env_vars includes FOO_APIKEY, then the build container will also have FOO_APIKEY=secret123 set.
+
+In most cases where this is used, the environment variables will also need to be passed to the container securely. To do this, you'll need to add the required secrets to your params. Here's a generic example:
+
+```
+builds:
+  docker:
+    image: mergermarket/cdflow2-build-docker-ecr
+    params:
+      buildx: true
+      platforms: linux/arm64,linux/amd64
+      secrets:
+        - 'id=FOO_APIKEY,env=FOO_APIKEY'
+    env_vars:
+      - FOO_APIKEY
+```
+
+More information can be found here:
+https://docs.docker.com/build/building/secrets/#sources
 
 ### `terraform > image` (required)
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -52,4 +52,5 @@ and the build is published somewhere (the software is "released"), followed by o
 
 * [Install cdflow2](installation)
 * [Project Setup](project-setup)
+* [cdflow.yaml Reference](cdflow-yaml-reference)
 * [cdflow2 Design](design)

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -13,7 +13,7 @@ type Manifest struct {
 	Version           int8                       `yaml:"version"`
 	ConfigFilesFolder string                     `yaml:"config_files_folder"`
 	Config            ImageWithParams            `yaml:"config"`
-	Builds            map[string]ImageWithParams `yaml:"builds"`
+	Builds            map[string]ImageWithParamsAndEnvVars `yaml:"builds"`
 	Terraform         Terraform                  `yaml:"terraform"`
 }
 
@@ -21,6 +21,12 @@ type Manifest struct {
 type ImageWithParams struct {
 	Image  string                 `yaml:"image"`
 	Params map[string]interface{} `yaml:"params"`
+}
+
+type ImageWithParamsAndEnvVars struct {
+	Image  string                 `yaml:"image"`
+	Params map[string]interface{} `yaml:"params"`
+	EnvVars []string              `yaml:"envvars"`
 }
 
 // Terraform represents the data in the terraform key in cdflow.yaml.

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -10,11 +10,11 @@ import (
 
 // Manifest represents the data in the cdflow.yaml file before it is canonicalised.
 type Manifest struct {
-	Version           int8                       `yaml:"version"`
-	ConfigFilesFolder string                     `yaml:"config_files_folder"`
-	Config            ImageWithParams            `yaml:"config"`
+	Version           int8                                 `yaml:"version"`
+	ConfigFilesFolder string                               `yaml:"config_files_folder"`
+	Config            ImageWithParams                      `yaml:"config"`
 	Builds            map[string]ImageWithParamsAndEnvVars `yaml:"builds"`
-	Terraform         Terraform                  `yaml:"terraform"`
+	Terraform         Terraform                            `yaml:"terraform"`
 }
 
 // ImageWithParams represents either the config or a build key in cdflow.yaml.
@@ -24,9 +24,9 @@ type ImageWithParams struct {
 }
 
 type ImageWithParamsAndEnvVars struct {
-	Image  string                 `yaml:"image"`
-	Params map[string]interface{} `yaml:"params"`
-	EnvVars []string              `yaml:"envvars"`
+	Image   string                 `yaml:"image"`
+	Params  map[string]interface{} `yaml:"params"`
+	EnvVars []string               `yaml:"env_vars"`
 }
 
 // Terraform represents the data in the terraform key in cdflow.yaml.

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -17,7 +17,7 @@ func TestLoad(t *testing.T) {
 	if loadedManifest.Version != 2 {
 		log.Fatalln("unexpected version:", loadedManifest.Version)
 	}
-	if !reflect.DeepEqual(loadedManifest.Builds, map[string]manifest.ImageWithParams{
+	if !reflect.DeepEqual(loadedManifest.Builds, map[string]manifest.ImageWithParamsAndEnvVars{
 		"release": {Image: "test-release-image"},
 	}) {
 		log.Fatalln("unexpected release data from manifest:", loadedManifest.Builds)

--- a/release/command/command.go
+++ b/release/command/command.go
@@ -297,15 +297,18 @@ func buildAndUploadRelease(state *command.GlobalState, buildVolume, version stri
 		// Iterate over each environment variable name in build.EnvVars,
 		// retrieve its value from the environment, and add it to the env map
 		// without printing the value to avoid leaking secrets.
-		for _, envvar := range build.EnvVars {
-			v := os.Getenv(envvar)
-			if v == "" {
-				fmt.Printf("\nWarning: Environment variable %s is not set in host environment.\n\n", envvar)
+		for _, envVarName := range build.EnvVars {
+			envValue := os.Getenv(envVarName)
+			if envValue == "" {
+				fmt.Printf("\n- WARN: Environment variable '%s' is not set in host environment.", envVarName)
 			} else {
-				fmt.Printf("\n\nAdding Environment variable %s into cdflow release container.\n\n", envvar)
+				fmt.Printf("\n- Adding Environment variable '%s' into cdflow release container.", envVarName)
 			}
-			env[envvar] = v
+			env[envVarName] = envValue
 		}
+
+		// For output readability
+		fmt.Printf("\n\n")
 
 		// these are built in and cannot be overridden by the config container (since choosing the clashing name would likely be an accident)
 		env["VERSION"] = version

--- a/release/command/command.go
+++ b/release/command/command.go
@@ -293,6 +293,19 @@ func buildAndUploadRelease(state *command.GlobalState, buildVolume, version stri
 		if env == nil {
 			env = make(map[string]string)
 		}
+		
+		// Iterate over each environment variable name in build.EnvVars,
+		// retrieve its value from the environment, and add it to the env map
+		// without printing the value to avoid leaking secrets.
+		for _, envvar := range build.EnvVars {
+			v := os.Getenv(envvar)
+			if v == "" {
+				fmt.Printf("\nWarning: Environment variable %s is not set in host environment.\n\n", envvar)
+			} else {
+				fmt.Printf("\n\nAdding Environment variable %s into cdflow release container.\n\n", envvar)
+			}
+			env[envvar] = v
+		}
 
 		// these are built in and cannot be overridden by the config container (since choosing the clashing name would likely be an accident)
 		env["VERSION"] = version

--- a/release/command/command_test.go
+++ b/release/command/command_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"io"
 	"log"
+	"os"
 	"strings"
 	"testing"
 
@@ -277,5 +279,60 @@ func checkUploadReleaseOutput(t *testing.T, debugOutput []byte) {
 
 	if decoded.ReleaseMetadata["buildid"]["manifest_params"] != "{\"a\":\"b\"}" {
 		t.Fatal("unexpected manifest_params:", decoded.ReleaseMetadata["buildid"]["manifest_params"])
+	}
+}
+
+func TestPopulateEnvMap(t *testing.T) {
+
+	// Set environment variable EXISTING_VAR
+	os.Setenv("EXISTING_VAR", "test_value")
+
+	// Ensure MISSING_VAR is Not set
+	os.Unsetenv("MISSING_VAR")
+
+	// set envVars map and init env
+	envVars := []string{"EXISTING_VAR", "MISSING_VAR"}
+	env := make(map[string]string)
+
+	// Setup the ability to capture stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Failed to create pipe: %v", err)
+	}
+
+	// Start stdout capture
+	originalStdout := os.Stdout
+	os.Stdout = writer
+
+	release.PopulateEnvMap(envVars, env)
+
+	// end stdout capture
+	writer.Close()
+	os.Stdout = originalStdout
+
+	// Read the captured output
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, reader)
+	if err != nil {
+		t.Fatalf("Failed to read stdout: %v", err)
+	}
+
+	// Check if EXISTING_VAR env var are in the env map and the value is correct.
+	if env["EXISTING_VAR"] != "test_value" {
+		t.Errorf("Expected EXISTING_VAR to be 'test_value', got '%s'", env["EXISTING_VAR"])
+	}
+
+	// Check if MISSING_VAR env var is NOT in the map and the value is a empty string.
+	if env["MISSING_VAR"] != "" {
+		t.Errorf("Expected MISSING_VAR to be empty string, got '%s'", env["MISSING_VAR"])
+	}
+
+	// Validate Log Output.
+	output := buf.String()
+	if !bytes.Contains([]byte(output), []byte("Adding Environment variable 'EXISTING_VAR'")) {
+		t.Errorf("Expected log about EXISTING_VAR, got: %s", output)
+	}
+	if !bytes.Contains([]byte(output), []byte("Environment variable 'MISSING_VAR' is not set")) {
+		t.Errorf("Expected log about MISSING_VAR, got: %s", output)
 	}
 }

--- a/release/command/command_test.go
+++ b/release/command/command_test.go
@@ -148,10 +148,11 @@ func TestRunCommand(t *testing.T) {
 			CodeDir:      test.GetConfig("TEST_ROOT") + "/test/release/sample-code",
 			Manifest: &manifest.Manifest{
 				Version: 2,
-				Builds: map[string]manifest.ImageWithParams{
+				Builds: map[string]manifest.ImageWithParamsAndEnvVars{
 					"buildid": {
-						Image:  test.GetConfig("TEST_RELEASE_IMAGE"),
-						Params: map[string]interface{}{"a": "b"},
+						Image:   test.GetConfig("TEST_RELEASE_IMAGE"),
+						Params:  map[string]interface{}{"a": "b"},
+						EnvVars: []string{"FOO"},
 					},
 				},
 				Terraform: manifest.Terraform{

--- a/setup/command_test.go
+++ b/setup/command_test.go
@@ -31,7 +31,7 @@ func TestRunCommand(t *testing.T) {
 			CodeDir:      test.GetConfig("TEST_ROOT") + "/test/release/sample-code",
 			Manifest: &manifest.Manifest{
 				Version: 2,
-				Builds: map[string]manifest.ImageWithParams{
+				Builds: map[string]manifest.ImageWithParamsAndEnvVars{
 					"release": {
 						Image: test.GetConfig("TEST_RELEASE_IMAGE"),
 					},


### PR DESCRIPTION
- Added envvars to build config via new ImageWithParamsAndEnvVars type
- Injects specified env vars into release container at runtime

Backstop JIRA related ticket: [DEVOPS-10050 Inject Build Env Vars into CDflow release Container](https://jira.backstop.solutions/browse/DEVOPS-10050)